### PR TITLE
add support to connect to tls host with spesific tls version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Flags:
         Generate intermediate certificate
   -read  <filename>
         Read certificate information from file server.local.pem
-  -connect  <host:443>
+  -connect  <host:443> <tlsver:1.2>
         Show certificate information from remote host
   -export-p12  <cert> <private-key> <ca-cert>
         Generate client.p12 pem file containing certificate, private key and ca certificate

--- a/cmd/certify/command.go
+++ b/cmd/certify/command.go
@@ -59,7 +59,9 @@ func readRemoteCertificate(args []string) (string, error) {
 		return "", fmt.Errorf("you must provide remote host")
 	}
 
-	result, err := tlsDial(args[2])
+	tlsConfig := parseTLSVersion(args)
+
+	result, err := tlsDial(args[2], tlsConfig)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Introduce new argument (`tlsVer:`) to set specific tls version when connecting to the remote host.

Example
```
certify -connect google.com:443 tlsVer:1.2
```