### PR TITLE
feat: allow to use insecure-flag and allow to use custom ca on certif…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Flags:
         Generate intermediate certificate
   -read  <filename>
         Read certificate information from file server.local.pem
-  -connect  <host:443> <tlsver:1.2>
+  -connect  <host:443> <tlsver:1.2> <insecure> <with-ca:ca-path>
         Show certificate information from remote host, use tlsver to set spesific tls version
   -export-p12  <cert> <private-key> <ca-cert>
         Generate client.p12 pem file containing certificate, private key and ca certificate

--- a/cmd/certify/helper.go
+++ b/cmd/certify/helper.go
@@ -428,36 +428,51 @@ func isExist(path string) bool {
 	return !errors.Is(err, os.ErrNotExist)
 }
 
-func parseTLSVersion(args []string) *tls.Config {
+func parseTLSVersion(args []string) uint16 {
 	for _, arg := range args[1:] {
 		if strings.Contains(arg, "tlsver:") {
 			ver := strings.Split(arg, ":")[1]
-			return setTLSVersion(ver)
+			return getTLSVersion(ver)
 		}
 	}
 
 	log.Println("use default settings ...")
-	return &tls.Config{}
+	return tls.VersionTLS12
 }
 
-func setTLSVersion(ver string) *tls.Config {
-	tlsConfig := &tls.Config{}
-
-	if ver == "1.0" {
-		tlsConfig.MinVersion = tls.VersionTLS10
-		tlsConfig.MaxVersion = tls.VersionTLS10
-	} else if ver == "1.1" {
-		tlsConfig.MinVersion = tls.VersionTLS11
-		tlsConfig.MaxVersion = tls.VersionTLS11
-	} else if ver == "1.2" {
-		tlsConfig.MinVersion = tls.VersionTLS12
-		tlsConfig.MaxVersion = tls.VersionTLS12
-	} else if ver == "1.3" {
-		tlsConfig.MinVersion = tls.VersionTLS13
-		tlsConfig.MaxVersion = tls.VersionTLS13
+func parseInsecureArg(args []string) bool {
+	for _, arg := range args[1:] {
+		if strings.Contains(arg, "insecure") {
+			return true
+		}
 	}
 
-	return tlsConfig
+	return false
+}
+
+func parseCAarg(args []string) string {
+	for _, arg := range args[1:] {
+		if strings.Contains(arg, "with-ca:") {
+			// return ca path
+			return strings.Split(arg, ":")[1]
+		}
+	}
+
+	return ""
+}
+
+func getTLSVersion(ver string) uint16 {
+	if ver == "1.0" {
+		return tls.VersionTLS10
+	} else if ver == "1.1" {
+		return tls.VersionTLS11
+	} else if ver == "1.2" {
+		return tls.VersionTLS12
+	} else if ver == "1.3" {
+		return tls.VersionTLS13
+	}
+
+	return tls.VersionTLS12
 }
 
 func tlsDial(host string, tlsConfig *tls.Config) (*x509.Certificate, error) {

--- a/cmd/certify/helper_test.go
+++ b/cmd/certify/helper_test.go
@@ -598,3 +598,66 @@ func TestParseTLSVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestParseInsecureArg(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Args     []string
+		Expected bool
+	}{
+		{
+			Name:     "Test using insecure arg enabled",
+			Args:     []string{"certify", "-connect", "google.com:443", "insecure"},
+			Expected: true,
+		},
+		{
+			Name:     "Test without insecure flag",
+			Args:     []string{"certify", "-connect", "google.com:443", "tlsver:1.1"},
+			Expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			config := parseInsecureArg(tt.Args)
+
+			if !reflect.DeepEqual(config, tt.Expected) {
+				t.Fatalf("got %v, want %v", config, tt.Expected)
+			}
+		})
+	}
+}
+
+func TestParseCAArg(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Args     []string
+		Expected string
+	}{
+		{
+			Name:     "Test with ca arg",
+			Args:     []string{"certify", "-connect", "google.com:443", "with-ca:/tmp/ca-cert.pem"},
+			Expected: "/tmp/ca-cert.pem",
+		},
+		{
+			Name:     "Test with ca arg without value",
+			Args:     []string{"certify", "-connect", "google.com:443", "with-ca:"},
+			Expected: "",
+		},
+		{
+			Name:     "Test without ca arg",
+			Args:     []string{"certify", "-connect", "google.com:443"},
+			Expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			config := parseCAarg(tt.Args)
+
+			if !reflect.DeepEqual(config, tt.Expected) {
+				t.Fatalf("got %v, want %v", config, tt.Expected)
+			}
+		})
+	}
+}

--- a/cmd/certify/helper_test.go
+++ b/cmd/certify/helper_test.go
@@ -541,61 +541,49 @@ func TestParseTLSVersion(t *testing.T) {
 	tests := []struct {
 		Name           string
 		Args           []string
-		ExpectedConfig *tls.Config
+		ExpectedConfig uint16
 		ExpectedErr    error
 	}{
 		{
-			Name: "Test using tls version 1.0",
-			Args: []string{"certify", "-connect", "google.com:443", "tlsver:1.0"},
-			ExpectedConfig: &tls.Config{
-				MinVersion: tls.VersionTLS10,
-				MaxVersion: tls.VersionTLS10,
-			},
-			ExpectedErr: nil,
+			Name:           "Test using tls version 1.0",
+			Args:           []string{"certify", "-connect", "google.com:443", "tlsver:1.0"},
+			ExpectedConfig: tls.VersionTLS10,
+			ExpectedErr:    nil,
 		},
 		{
-			Name: "Test using tls version 1.1",
-			Args: []string{"certify", "-connect", "google.com:443", "tlsver:1.1"},
-			ExpectedConfig: &tls.Config{
-				MinVersion: tls.VersionTLS11,
-				MaxVersion: tls.VersionTLS11,
-			},
-			ExpectedErr: nil,
+			Name:           "Test using tls version 1.1",
+			Args:           []string{"certify", "-connect", "google.com:443", "tlsver:1.1"},
+			ExpectedConfig: tls.VersionTLS11,
+			ExpectedErr:    nil,
 		},
 		{
-			Name: "Test using tls version 1.2",
-			Args: []string{"certify", "-connect", "google.com:443", "tlsver:1.2"},
-			ExpectedConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-				MaxVersion: tls.VersionTLS12,
-			},
-			ExpectedErr: nil,
+			Name:           "Test using tls version 1.2",
+			Args:           []string{"certify", "-connect", "google.com:443", "tlsver:1.2"},
+			ExpectedConfig: tls.VersionTLS12,
+			ExpectedErr:    nil,
 		},
 		{
-			Name: "Test using tls version 1.3",
-			Args: []string{"certify", "-connect", "google.com:443", "tlsver:1.3"},
-			ExpectedConfig: &tls.Config{
-				MinVersion: tls.VersionTLS13,
-				MaxVersion: tls.VersionTLS13,
-			},
-			ExpectedErr: nil,
+			Name:           "Test using tls version 1.3",
+			Args:           []string{"certify", "-connect", "google.com:443", "tlsver:1.3"},
+			ExpectedConfig: tls.VersionTLS13,
+			ExpectedErr:    nil,
 		},
 		{
 			Name:           "Test using not available tls version",
 			Args:           []string{"certify", "-connect", "google.com:443", "tlsver:1.4"},
-			ExpectedConfig: &tls.Config{},
+			ExpectedConfig: tls.VersionTLS12,
 			ExpectedErr:    nil,
 		},
 		{
 			Name:           "Test using not available tls version",
 			Args:           []string{"certify", "-connect", "google.com:443", "tlsver:sslv3"},
-			ExpectedConfig: &tls.Config{},
+			ExpectedConfig: tls.VersionTLS12,
 			ExpectedErr:    nil,
 		},
 		{
 			Name:           "Test without provide tls version",
 			Args:           []string{"certify", "-connect", "google.com:443"},
-			ExpectedConfig: &tls.Config{},
+			ExpectedConfig: tls.VersionTLS12,
 			ExpectedErr:    nil,
 		},
 	}

--- a/cmd/certify/main.go
+++ b/cmd/certify/main.go
@@ -28,7 +28,7 @@ Flags:
 	Generate intermediate certificate
   -read  <filename>
 	Read certificate information from file server.local.pem
-  -connect  <host:443> <tlsver:1.2>
+  -connect  <host:443> <tlsver:1.2> <insecure> <with-ca:ca-path>
 	Show certificate information from remote host, use tlsver to set spesific tls version
   -export-p12  <cert> <private-key> <ca-cert>
 	Generate client.p12 pem file containing certificate, private key and ca certificate


### PR DESCRIPTION
this MR allows user to:
- Connect to service with provided CA, user just need to provide `with-ca:` arg followed by CA path
- Allow user to disable CA verification