### PR TITLE
feat: add AKI, SKI and keyUsage info to certificates

### DIFF
--- a/certify.go
+++ b/certify.go
@@ -29,6 +29,7 @@ type Certificate struct {
 	KeyUsage         x509.KeyUsage
 	ExtentedKeyUsage []x509.ExtKeyUsage
 	SubjectKeyId     []byte
+	AuthorityKeyId   []byte
 }
 
 // Result hold created certificate in []byte format
@@ -61,6 +62,7 @@ func (c *Certificate) SetTemplate() x509.Certificate {
 		DNSNames:              c.DNSNames,
 		BasicConstraintsValid: true,
 		SubjectKeyId:          c.SubjectKeyId,
+		AuthorityKeyId:        c.AuthorityKeyId,
 	}
 }
 


### PR DESCRIPTION
Currently generated certificate doesn't have AKI, SKI and KeyUsage information, on this PR we adding these information the generated certificates